### PR TITLE
fix evaluations response

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,8 +13,8 @@ EXT_DIR            := ./.ext
 EXT_BIN_DIR        := ${EXT_DIR}/bin
 EXT_TMP_DIR        := ${EXT_DIR}/tmp
 
-SVU_VER 	         := 2.2.0
-BUF_VER            := 1.50.0
+SVU_VER 	         := 3.2.3
+BUF_VER            := 1.54.0
 
 PROJECT            := access
 

--- a/proto/access/v1/access.proto
+++ b/proto/access/v1/access.proto
@@ -153,7 +153,7 @@ message EvaluationsRequest {
 
 // https://openid.github.io/authzen/#name-access-evaluations-api-resp
 message EvaluationsResponse {
-  repeated EvaluationResponse decisions = 1;
+  repeated EvaluationResponse evaluations = 1;
 }
 
 // https://openid.github.io/authzen/#name-the-subject-search-api-requ


### PR DESCRIPTION
The `evaluations` response container is named `evaluations` instead of `decisions`.